### PR TITLE
Don't use freetype

### DIFF
--- a/bridge/CMakeLists.txt
+++ b/bridge/CMakeLists.txt
@@ -10,6 +10,8 @@ include(FetchContent)
 
 set(CXX_JUCE_VERSION_OF_JUCE 7.0.12)
 
+add_compile_definitions (JUCE_USE_FREETYPE=0)
+
 FetchContent_Declare(
     JUCE
     GIT_REPOSITORY https://github.com/juce-framework/JUCE.git


### PR DESCRIPTION
This seems to be broken on CI - see https://forum.juce.com/t/cannot-compile-juce-graphics-cpp-on-linux-anymore-switching-to-juce8/61854