### PR TITLE
Improve build times

### DIFF
--- a/bridge/CMakeLists.txt
+++ b/bridge/CMakeLists.txt
@@ -5,11 +5,11 @@ project(cxx-juce VERSION 0.1)
 set(CXX_JUCE_BINDINGS_DIR "" CACHE PATH "Path to the bindings directory")
 set(CXX_JUCE_USE_ASIO OFF CACHE BOOL "Use ASIO")
 set(CXX_JUCE_ASIO_SDK_DIR "" CACHE PATH "Path to the ASIO SDK directory")
-
-include(FetchContent)
-
 set(CXX_JUCE_VERSION_OF_JUCE 7.0.12)
 
+set(JUCE_MODULES_ONLY ON)
+
+include(FetchContent)
 FetchContent_Declare(
     JUCE
     GIT_REPOSITORY https://github.com/juce-framework/JUCE.git
@@ -20,8 +20,6 @@ message(STATUS "Fetching JUCE ${CXX_JUCE_VERSION_OF_JUCE}...")
 FetchContent_MakeAvailable(JUCE)
 
 add_library(cxx-juce STATIC)
-
-_juce_initialise_target(cxx-juce)
 
 target_compile_features(cxx-juce
     PUBLIC

--- a/bridge/CMakeLists.txt
+++ b/bridge/CMakeLists.txt
@@ -10,12 +10,12 @@ set(CXX_JUCE_VERSION_OF_JUCE 7.0.12)
 set(JUCE_MODULES_ONLY ON)
 
 include(FetchContent)
+set(JUCE_URL https://github.com/juce-framework/JUCE/archive/refs/tags/${CXX_JUCE_VERSION_OF_JUCE}.tar.gz)
 FetchContent_Declare(
     JUCE
-    GIT_REPOSITORY https://github.com/juce-framework/JUCE.git
-    GIT_TAG ${CXX_JUCE_VERSION_OF_JUCE}
+    URL ${JUCE_URL}
+    URL_HASH SHA256=94e3b35e1990cd67f59736bb5e1eff1cfd9590b16fea82696f309a8f59452434
 )
-
 message(STATUS "Fetching JUCE ${CXX_JUCE_VERSION_OF_JUCE}...")
 FetchContent_MakeAvailable(JUCE)
 

--- a/build.rs
+++ b/build.rs
@@ -39,11 +39,19 @@ fn main() {
     println!("cargo:rerun-if-changed=bridge");
     println!("cargo:rerun-if-env-changed=CXX_JUCE_ASIO_SDK_DIR");
 
-    println!(
-        "cargo:rustc-link-search=native={}/build/cxx-juce_artefacts/{}",
-        destination.display(),
-        cmake.get_profile(),
-    );
+    if cfg!(target_os = "windows") {
+        println!(
+            "cargo:rustc-link-search=native={}/build/{}",
+            destination.display(),
+            cmake.get_profile()
+        );
+    } else {
+        println!(
+            "cargo:rustc-link-search=native={}/build",
+            destination.display()
+        );
+    };
+
     println!("cargo:rustc-link-lib=static=cxx-juce");
 
     if cfg!(target_os = "macos") {


### PR DESCRIPTION
- Use JUCE_MODULES_ONLY option
- Fetch from GitHub release .tar.gz instead of git.