### PR TITLE
Use absolute paths for cxx bridge files

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -28,11 +28,12 @@ fn main() {
     let mut cmake = cmake::Config::new("bridge");
     cmake.build_target("cxx-juce");
 
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
     cmake.define(
         "CXX_JUCE_BRIDGE_FILES",
         bridges
             .iter()
-            .map(|bridge| format!("../target/cxxbridge/cxx-juce/{}.cc", bridge))
+            .map(|bridge| format!("{}/target/cxxbridge/cxx-juce/{}.cc", manifest_dir, bridge))
             .collect::<Vec<_>>()
             .join(";"),
     );


### PR DESCRIPTION
I tested your new updated, great work!

The project does only not build when used as a dependency in other rust projects, that's why I made the path to the cxx bridge files global.

And great talk at ADC btw :)