### PR TITLE
Don't wrap JUCE interfaces

### DIFF
--- a/bridge/cxx_juce.h
+++ b/bridge/cxx_juce.h
@@ -56,10 +56,4 @@ auto eq (const T& a, const T& b)
     return a == b;
 }
 
-template <typename T>
-std::unique_ptr<T> forceUniquePtrTarget ()
-{
-    return std::unique_ptr<T>{};
-}
-
 } // namespace cxx_juce

--- a/bridge/cxx_juce_audio_devices/cxx_juce_audio_io_device.cpp
+++ b/bridge/cxx_juce_audio_devices/cxx_juce_audio_io_device.cpp
@@ -6,18 +6,9 @@
 namespace cxx_juce
 {
 
-BoxDynAudioDevice::BoxDynAudioDevice (BoxDynAudioDevice&& other) noexcept
-    : _repr { other._repr }
+void DropBoxDynAudioDevice::operator() (BoxDynAudioDevice* device) const
 {
-    other._repr = { 0, 0 };
-}
-
-BoxDynAudioDevice::~BoxDynAudioDevice() noexcept
-{
-    if (_repr != FatPtr { 0, 0 })
-    {
-        BoxDynAudioIODeviceImpl::drop (this);
-    }
+    BoxDynAudioIODeviceImpl::drop (device);
 }
 
 std::unique_ptr<juce::AudioIODevice> wrapAudioDevice (BoxDynAudioDevice device)

--- a/bridge/cxx_juce_audio_devices/cxx_juce_audio_io_device.h
+++ b/bridge/cxx_juce_audio_devices/cxx_juce_audio_io_device.h
@@ -2,21 +2,16 @@
 
 #include <juce_audio_devices/juce_audio_devices.h>
 
+#include <cxx_juce_utils.h>
+
 namespace cxx_juce
 {
-
-class BoxDynAudioDevice
+struct DropBoxDynAudioDevice
 {
-    using FatPtr = std::array<std::uintptr_t, 2>;
-
-public:
-    BoxDynAudioDevice (BoxDynAudioDevice&& other) noexcept;
-    ~BoxDynAudioDevice() noexcept;
-    using IsRelocatable = std::true_type;
-
-private:
-    FatPtr _repr;
+    void operator() (FatPtr<DropBoxDynAudioDevice>* device) const;
 };
+
+using BoxDynAudioDevice = FatPtr<DropBoxDynAudioDevice>;
 
 std::unique_ptr<juce::AudioIODevice> wrapAudioDevice (BoxDynAudioDevice device);
 } // namespace cxx_juce

--- a/bridge/cxx_juce_audio_devices/cxx_juce_audio_io_device_callback.cpp
+++ b/bridge/cxx_juce_audio_devices/cxx_juce_audio_io_device_callback.cpp
@@ -5,18 +5,9 @@
 
 namespace cxx_juce
 {
-BoxDynAudioDeviceCallback::BoxDynAudioDeviceCallback (BoxDynAudioDeviceCallback&& other) noexcept
-    : _repr { other._repr }
+void DropBoxDynAudioDeviceCallback::operator() (BoxDynAudioDeviceCallback* callback) const
 {
-    other._repr = { 0, 0 };
-}
-
-BoxDynAudioDeviceCallback::~BoxDynAudioDeviceCallback() noexcept
-{
-    if (_repr != FatPtr { 0, 0 })
-    {
-        BoxDynAudioDeviceCallbackImpl::drop (this);
-    }
+    BoxDynAudioDeviceCallbackImpl::drop (callback);
 }
 
 std::unique_ptr<juce::AudioIODeviceCallback> wrapAudioDeviceCallback (BoxDynAudioDeviceCallback callback)

--- a/bridge/cxx_juce_audio_devices/cxx_juce_audio_io_device_callback.h
+++ b/bridge/cxx_juce_audio_devices/cxx_juce_audio_io_device_callback.h
@@ -2,21 +2,17 @@
 
 #include <juce_audio_devices/juce_audio_devices.h>
 
+#include <cxx_juce_utils.h>
+
 namespace cxx_juce
 {
 
-class BoxDynAudioDeviceCallback
+struct DropBoxDynAudioDeviceCallback
 {
-    using FatPtr = std::array<std::uintptr_t, 2>;
-
-public:
-    BoxDynAudioDeviceCallback (BoxDynAudioDeviceCallback&& other) noexcept;
-    ~BoxDynAudioDeviceCallback() noexcept;
-    using IsRelocatable = std::true_type;
-
-private:
-    FatPtr _repr;
+    void operator() (FatPtr<DropBoxDynAudioDeviceCallback>* callback) const;
 };
+
+using BoxDynAudioDeviceCallback = FatPtr<DropBoxDynAudioDeviceCallback>;
 
 std::unique_ptr<juce::AudioIODeviceCallback> wrapAudioDeviceCallback (BoxDynAudioDeviceCallback callback);
 

--- a/bridge/cxx_juce_audio_devices/cxx_juce_audio_io_device_type.cpp
+++ b/bridge/cxx_juce_audio_devices/cxx_juce_audio_io_device_type.cpp
@@ -5,18 +5,9 @@
 
 namespace cxx_juce
 {
-BoxDynAudioIODeviceType::BoxDynAudioIODeviceType (BoxDynAudioIODeviceType&& other) noexcept
-    : _repr { other._repr }
+void DropBoxDynAudioIODeviceType::operator() (BoxDynAudioIODeviceType* deviceType) const
 {
-    other._repr = { 0, 0 };
-}
-
-BoxDynAudioIODeviceType::~BoxDynAudioIODeviceType() noexcept
-{
-    if (_repr != FatPtr { 0, 0 })
-    {
-        BoxDynAudioIODeviceTypeImpl::drop (this);
-    }
+    BoxDynAudioIODeviceTypeImpl::drop (deviceType);
 }
 
 std::unique_ptr<juce::AudioIODeviceType> wrapAudioDeviceType (BoxDynAudioIODeviceType deviceType)
@@ -68,8 +59,7 @@ std::unique_ptr<juce::AudioIODeviceType> wrapAudioDeviceType (BoxDynAudioIODevic
         {
             try
             {
-                auto box = BoxDynAudioIODeviceTypeImpl::create_device (_deviceType, inputDeviceName, outputDeviceName);
-                return wrapAudioDevice (std::move (box)).release();
+                return BoxDynAudioIODeviceTypeImpl::create_device (_deviceType, inputDeviceName, outputDeviceName).release();
             }
             catch (const rust::Error&)
             {

--- a/bridge/cxx_juce_audio_devices/cxx_juce_audio_io_device_type.h
+++ b/bridge/cxx_juce_audio_devices/cxx_juce_audio_io_device_type.h
@@ -2,21 +2,17 @@
 
 #include <juce_audio_devices/juce_audio_devices.h>
 
+#include <cxx_juce_utils.h>
+
 namespace cxx_juce
 {
 
-class BoxDynAudioIODeviceType
+struct DropBoxDynAudioIODeviceType
 {
-    using FatPtr = std::array<std::uintptr_t, 2>;
-
-public:
-    BoxDynAudioIODeviceType (BoxDynAudioIODeviceType&& other) noexcept;
-    ~BoxDynAudioIODeviceType() noexcept;
-    using IsRelocatable = std::true_type;
-
-private:
-    FatPtr _repr;
+    void operator() (FatPtr<DropBoxDynAudioIODeviceType>* deviceType) const;
 };
+
+using BoxDynAudioIODeviceType = FatPtr<DropBoxDynAudioIODeviceType>;
 
 std::unique_ptr<juce::AudioIODeviceType> wrapAudioDeviceType (BoxDynAudioIODeviceType deviceType);
 } // namespace cxx_juce

--- a/bridge/cxx_juce_utils.h
+++ b/bridge/cxx_juce_utils.h
@@ -1,8 +1,45 @@
 #pragma once
 
+#include <rust/cxx.h>
+
+#include <array>
+
 #define CXX_JUCE_ASSERT_SIZE_ALIGN(TYPE, LAYOUT)                                 \
     static_assert (sizeof (juce ::TYPE) == static_cast<size_t> (LAYOUT ::Size)); \
     static_assert (alignof (juce ::TYPE) == static_cast<size_t> (LAYOUT ::Alignment));
 
 #define CXX_JUCE_ASSERT_FIELD_OFFSET(TYPE, FIELD, OFFSET) \
     static_assert (offsetof (juce ::TYPE, FIELD) == static_cast<size_t> (OFFSET));
+
+namespace cxx_juce
+{
+template <typename Deleter>
+class FatPtr
+{
+    using Repr = std::array<std::uintptr_t, 2>;
+    static constexpr auto null = Repr { 0, 0 };
+
+public:
+    FatPtr (FatPtr&& other) noexcept
+        : _repr { other._repr }
+    {
+        other._repr = null;
+    }
+
+    ~FatPtr() noexcept
+    {
+        if (_repr != null)
+        {
+            Deleter {}(this);
+        }
+    }
+
+private:
+    Repr _repr {};
+};
+} // namespace cxx_juce
+
+template <typename Deleter>
+struct rust::IsRelocatable<cxx_juce::FatPtr<Deleter>> : std::true_type
+{
+};

--- a/examples/audio_callback.rs
+++ b/examples/audio_callback.rs
@@ -1,7 +1,7 @@
 use {
     cxx_juce::{
         juce_audio_basics::AudioSampleBuffer,
-        juce_audio_devices::{AudioDevice, AudioDeviceCallback, AudioDeviceManager},
+        juce_audio_devices::{AudioDeviceCallback, AudioDeviceManager, AudioIODevice},
         JuceError, JUCE,
     },
     std::{iter::successors, pin::Pin, thread::sleep, time::Duration},
@@ -31,23 +31,27 @@ struct AudioCallback {
 }
 
 impl AudioDeviceCallback for AudioCallback {
-    fn about_to_start(&mut self, device: &mut dyn AudioDevice) {
+    fn about_to_start(&mut self, mut device: Pin<&mut AudioIODevice>) {
         const STARTING_FREQUENCY: f64 = 1024.0;
 
-        let output_channels = device.output_channels() as usize;
+        let sample_rate = device.as_mut().get_current_sample_rate();
+
+        let output_channels = device
+            .get_active_output_channels()
+            .count_number_of_set_bits() as usize;
 
         self.tones = successors(
             Some(ToneGenerator {
                 amplitude: 0.25,
                 frequency: STARTING_FREQUENCY,
                 phase: 0.0,
-                increment: STARTING_FREQUENCY / device.sample_rate(),
+                increment: STARTING_FREQUENCY / sample_rate,
             }),
             |prev| {
                 let frequency = prev.frequency * 2.5;
                 Some(ToneGenerator {
                     frequency,
-                    increment: frequency / device.sample_rate(),
+                    increment: frequency / sample_rate,
                     ..*prev
                 })
             },

--- a/examples/devices.rs
+++ b/examples/devices.rs
@@ -1,7 +1,4 @@
-use cxx_juce::{
-    juce_audio_devices::{AudioDeviceManager, AudioDeviceType},
-    JuceError, JUCE,
-};
+use cxx_juce::{juce_audio_devices::AudioDeviceManager, JuceError, JUCE};
 
 fn main() -> Result<(), JuceError> {
     let juce = JUCE::initialise();
@@ -11,12 +8,12 @@ fn main() -> Result<(), JuceError> {
     let device_type = audio_device_manager.current_device_type().unwrap();
 
     println!("Inputs:");
-    for input in device_type.input_devices() {
+    for input in &device_type.get_input_device_names() {
         println!("  {}", input);
     }
 
     println!("Outputs:");
-    for output in device_type.output_devices() {
+    for output in &device_type.get_output_device_names() {
         println!("  {}", output);
     }
 

--- a/examples/test_tone.rs
+++ b/examples/test_tone.rs
@@ -1,8 +1,5 @@
 use {
-    cxx_juce::{
-        juce_audio_devices::{AudioDevice, AudioDeviceManager},
-        JuceError, JUCE,
-    },
+    cxx_juce::{juce_audio_devices::AudioDeviceManager, JuceError, JUCE},
     std::{thread::sleep, time::Duration},
 };
 
@@ -16,17 +13,20 @@ fn main() -> Result<(), JuceError> {
             .current_device()
             .expect("default device not found");
 
-        println!("Name: {}", device.name());
-        println!("Type: {}", device.type_name());
-        println!("Sample rate: {}", device.sample_rate());
-        println!("Buffer size: {}", device.buffer_size());
+        println!("Name: {}", device.get_name());
+        println!("Type: {}", device.get_type_name());
+        println!("Sample rate: {}", device.as_mut().get_current_sample_rate());
+        println!(
+            "Buffer size: {}",
+            device.as_mut().get_current_buffer_size_samples()
+        );
         println!(
             "Available sample rates: {:?}",
-            device.available_sample_rates()
+            device.as_mut().get_available_sample_rates()
         );
         println!(
             "Available buffer sizes: {:?}",
-            device.available_buffer_sizes()
+            device.as_mut().get_available_buffer_sizes()
         );
     }
 

--- a/src/juce_audio_devices/device_callback.rs
+++ b/src/juce_audio_devices/device_callback.rs
@@ -1,38 +1,8 @@
-use crate::{
-    juce_audio_basics::AudioSampleBuffer,
-    juce_audio_devices::{AudioDevice, AudioIODevice},
-};
+use crate::{juce_audio_basics::AudioSampleBuffer, juce_audio_devices::AudioIODevice};
 use cxx::UniquePtr;
 use std::pin::Pin;
 
-/// A trait that can be implemented to receive audio callbacks.
-///
-/// Types that implement this trait can be registered with [`AudioDeviceManager::add_audio_callback`].
-///
-/// This trait requires that implementors are [`Send`] because the callbacks will occur on the audio thread.
-pub trait AudioDeviceCallback: Send {
-    /// Called when the audio device is about to start.
-    fn about_to_start(&mut self, device: &mut dyn AudioDevice);
-
-    /// Process a block of incoming and outgoing audio.
-    fn process_block(&mut self, input: &AudioSampleBuffer, output: Pin<&mut AudioSampleBuffer>);
-
-    /// Called when the audio device has stopped.
-    fn stopped(&mut self);
-}
-
-unsafe impl cxx::ExternType for Box<dyn AudioDeviceCallback> {
-    type Id = cxx::type_id!("cxx_juce::BoxDynAudioDeviceCallback");
-    type Kind = cxx::kind::Trivial;
-}
-
 pub use juce::{AudioIODeviceCallback, BoxDynAudioDeviceCallback};
-
-impl AudioIODeviceCallback {
-    pub fn wrap(callback: Box<dyn AudioDeviceCallback>) -> UniquePtr<AudioIODeviceCallback> {
-        juce::wrap_audio_device_callback(callback)
-    }
-}
 
 #[cxx::bridge(namespace = "cxx_juce")]
 mod juce {
@@ -75,15 +45,39 @@ mod juce {
     }
 }
 
+/// A trait that can be implemented to receive audio callbacks.
+///
+/// Types that implement this trait can be registered with [`AudioDeviceManager::add_audio_callback`].
+///
+/// This trait requires that implementors are [`Send`] because the callbacks will occur on the audio thread.
+pub trait AudioDeviceCallback: Send {
+    /// Called when the audio device is about to start.
+    fn about_to_start(&mut self, device: Pin<&mut AudioIODevice>);
+
+    /// Process a block of incoming and outgoing audio.
+    fn process_block(&mut self, input: &AudioSampleBuffer, output: Pin<&mut AudioSampleBuffer>);
+
+    /// Called when the audio device has stopped.
+    fn stopped(&mut self);
+}
+
+unsafe impl cxx::ExternType for Box<dyn AudioDeviceCallback> {
+    type Id = cxx::type_id!("cxx_juce::BoxDynAudioDeviceCallback");
+    type Kind = cxx::kind::Trivial;
+}
+
+impl From<Box<dyn AudioDeviceCallback>> for UniquePtr<AudioIODeviceCallback> {
+    fn from(audio_device: Box<dyn AudioDeviceCallback>) -> Self {
+        juce::wrap_audio_device_callback(audio_device)
+    }
+}
+
 fn drop(callback: *mut Box<dyn AudioDeviceCallback>) {
     unsafe { std::ptr::drop_in_place(callback) };
 }
 
-fn about_to_start(
-    callback: &mut Box<dyn AudioDeviceCallback>,
-    mut device: Pin<&mut AudioIODevice>,
-) {
-    callback.about_to_start(&mut device);
+fn about_to_start(callback: &mut Box<dyn AudioDeviceCallback>, device: Pin<&mut AudioIODevice>) {
+    callback.about_to_start(device);
 }
 
 fn process_block(

--- a/src/juce_core/array.rs
+++ b/src/juce_core/array.rs
@@ -1,4 +1,5 @@
 use crate::define_juce_type;
+use std::fmt::Formatter;
 
 macro_rules! define_array {
     (
@@ -46,6 +47,12 @@ macro_rules! define_array {
                     .try_into()
                     .map(|size| unsafe { std::slice::from_raw_parts(data, size) })
                     .unwrap_or_default()
+            }
+        }
+
+        impl std::fmt::Debug for $name {
+            fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+                write!(f, "{:?}", self.as_ref())
             }
         }
     };

--- a/src/juce_core/string.rs
+++ b/src/juce_core/string.rs
@@ -54,15 +54,27 @@ impl From<JuceString> for String {
     }
 }
 
-impl std::fmt::Debug for JuceString {
+impl std::fmt::Display for JuceString {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.as_ref())
+    }
+}
+
+impl std::fmt::Debug for JuceString {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self.as_ref())
     }
 }
 
 impl PartialEq for JuceString {
     fn eq(&self, other: &Self) -> bool {
         juce::eq_string(self, other)
+    }
+}
+
+impl PartialEq<str> for JuceString {
+    fn eq(&self, other: &str) -> bool {
+        self.as_ref() == other
     }
 }
 


### PR DESCRIPTION
It's too awkward. Just return the interface rather than double bagging.