### PR TITLE
Update CXX_JUCE_BRIDGE_FILES path to use OUT_DIR

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -39,12 +39,12 @@ fn main() {
     let mut cmake = cmake::Config::new("bridge");
     cmake.build_target("cxx-juce");
 
-    let manifest_dir = env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
+    let out_dir = env::var("OUT_DIR").expect("OUT_DIR not set");
     cmake.define(
         "CXX_JUCE_BRIDGE_FILES",
         bridges
             .iter()
-            .map(|bridge| format!("{}/target/cxxbridge/cxx-juce/{}.cc", manifest_dir, bridge))
+            .map(|bridge| format!("{}/cxxbridge/sources/cxx-juce/{}.cc", out_dir, bridge))
             .collect::<Vec<_>>()
             .join(";"),
     );


### PR DESCRIPTION
When using the latest git revision as a crate dependency, CMake throws the following error:
```
CMake Error at CMakeLists.txt:48 (target_sources):
    Cannot find source file:

      G:/noise-supression-for-rnnoise/cxx-juce/target/cxxbridge/cxx-juce/src/juce_audio_basics/buffer.rs.cc
```
I found that `CARGO_MANIFEST_DIR` points to the `cxx-juce` external crate path instead of the main crate path where cxxbridge generates the source files. This fix ensures that crates using cxx-juce as a dependency can be built successfully."